### PR TITLE
fix: Update index.ts due to build errors on imported types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -189,16 +189,16 @@ export namespace Groq {
   export import toFile = Uploads.toFile;
   export import fileFromPath = Uploads.fileFromPath;
 
-  export import RequestOptions = Core.RequestOptions;
+  export type RequestOptions = Core.RequestOptions;
 
-  export import Chat = API.Chat;
+  export type Chat = API.Chat;
 
-  export import Audio = API.Audio;
-  export import Translation = API.Translation;
+  export type Audio = API.Audio;
+  export type Translation = API.Translation;
 
-  export import Models = API.Models;
-  export import Model = API.Model;
-  export import ModelList = API.ModelList;
+  export type Models = API.Models;
+  export type Model = API.Model;
+  export type ModelList = API.ModelList;
 }
 
 export default Groq;


### PR DESCRIPTION
This implementation avoids the TypeScript error shared below when building a solution that has a dependency on groq-sdk with the tsconfig isolatedModules = true which is the recommended approach. I think what you have is using the "legacy" implementation of exporting  types from namespaces where the types themselves were imported from other modules.

Look at this StackOverflow post:
https://stackoverflow.com/questions/30712638/typescript-export-imported-interface

Error I was getting:

./node_modules/.pnpm/groq-sdk@0.3.3/node_modules/groq-sdk/src/index.ts:192:3 Type error: Cannot use 'export import' on a type or type-only namespace when 'isolatedModules' is enabled.

  190 |   export import fileFromPath = Uploads.fileFromPath;
  191 |
> 192 |   export import RequestOptions = Core.RequestOptions;
      |   ^
  193 |
  194 |   export import Chat = API.Chat;
  195 |
 ELIFECYCLE  Command failed with exit code 1.