### PR TITLE
feat: schema based completions

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,13 +24,15 @@
     "fix": "./scripts/format"
   },
   "dependencies": {
+    "@standard-schema/spec": "^1.0.0",
     "@types/node": "^18.11.18",
     "@types/node-fetch": "^2.6.4",
     "abort-controller": "^3.0.0",
     "agentkeepalive": "^4.2.1",
     "form-data-encoder": "1.7.2",
     "formdata-node": "^4.3.2",
-    "node-fetch": "^2.6.7"
+    "node-fetch": "^2.6.7",
+    "xsschema": "^0.3.5"
   },
   "devDependencies": {
     "@swc/core": "^1.3.102",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,8 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
+import { schemaBasedCompletion, type SchemaBasedCompletionParams } from './lib/schema';
+import type { StandardSchemaV1 } from '@standard-schema/spec';
+
 import { type Agent } from './_shims/index';
 import * as Core from './core';
 import * as Errors from './error';
@@ -188,6 +191,12 @@ export class Groq extends Core.APIClient {
 
   protected override authHeaders(opts: Core.FinalRequestOptions): Core.Headers {
     return { Authorization: `Bearer ${this.apiKey}` };
+  }
+
+  buildSchemaBasedCompletion<I, O, S extends StandardSchemaV1<I, O>>(
+    schema: S,
+  ): (params: SchemaBasedCompletionParams) => Promise<O> {
+    return schemaBasedCompletion.bind(undefined, this, schema);
   }
 
   static Groq = this;

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -1,0 +1,44 @@
+import type { Groq } from '../index';
+import type { ChatCompletionCreateParamsNonStreaming } from '../resources/chat/completions';
+import type { StandardSchemaV1 } from '@standard-schema/spec';
+import { strictJsonSchema, toJsonSchema } from 'xsschema';
+
+type JsonSchema = Awaited<ReturnType<typeof toJsonSchema>>;
+const schemaCache = new WeakMap<StandardSchemaV1, JsonSchema>();
+async function getJsonSchema(schema: StandardSchemaV1) {
+  let cached = schemaCache.get(schema);
+  if (!cached) {
+    cached = await toJsonSchema(schema);
+    schemaCache.set(schema, cached);
+  }
+  cached = strictJsonSchema(cached);
+  return cached as Record<string, unknown>;
+}
+
+export type SchemaBasedCompletionParams = Omit<
+  ChatCompletionCreateParamsNonStreaming,
+  'response_format' | 'stream'
+>;
+export const schemaBasedCompletion = async (
+  client: Groq,
+  schema: StandardSchemaV1,
+  params: SchemaBasedCompletionParams,
+) => {
+  let response;
+  response = await client.chat.completions.create({
+    ...params,
+    response_format: {
+      type: 'json_schema',
+      json_schema: {
+        name: 'response',
+        schema: await getJsonSchema(schema),
+        strict: true,
+      },
+    },
+  });
+  const content = response.choices[0]?.message.content;
+  if (!content) {
+    throw new Error('No content in response. Ensure the model supports structured outputs.');
+  }
+  return JSON.parse(content);
+};


### PR DESCRIPTION
Not sure if this PR is mergeable, but it should be.

Idea is to make a convenience wrapper around structured outputs. This lets you do things like
```ts
// Declare schema once with anything Standard Schema compatible, like Arktype, and prebuild it
const personSchema = type({
  '+': 'reject',
  name: 'string',
  age: 'number',
  hobbies: 'string[]',
  location: {
    '+': 'reject',
    city: 'string',
    country: 'string',
  },
  favoriteNumbers: 'number[]',
});
const getPerson = groq.buildSchemaBasedCompletion(personSchema);

// Groq automatically turns the Standard Schema into a JSON schema and TS type...
const person = await getPerson({
  model: 'meta-llama/llama-4-scout-17b-16e-instruct',
  temperature: 0.2,
  messages: [
    {
      role: 'user',
      content: 'Astronaut',
    },
  ],
});

// ...so we know, both at compile time and runtime, that person will be of the correct type
console.dir(person, { depth: null });
```