### PR TITLE
[codex] chore(deps): bump js-yaml patched versions

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2395,9 +2395,9 @@ js-yaml@^3.13.1:
     esprima "^4.0.0"
 
 js-yaml@^4.1.1:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.2.0.tgz#2bd9e85682dd91bd469afb809d816043b3d49524"
-  integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
+  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
   dependencies:
     argparse "^2.0.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2387,17 +2387,17 @@ js-tokens@^4.0.0:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@^3.13.1:
-  version "3.14.2"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.2.tgz#77485ce1dd7f33c061fd1b16ecea23b55fcb04b0"
-  integrity sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.0.tgz#586e5214eafe3e893756a41e979b50d89d3e4a67"
+  integrity sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
 js-yaml@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
-  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.2.0.tgz#2bd9e85682dd91bd469afb809d816043b3d49524"
+  integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
## Summary

- Bump the two vulnerable transitive `js-yaml` lockfile entries:
  - `js-yaml@^4.1.1`: `4.1.1` -> `4.3.0`
  - `js-yaml@^3.13.1`: `3.14.2` -> `3.15.0`
- Keep the remediation lockfile-only; no package manifest or SDK source changes.

## Why

Vanta reports two open medium GitHub Dependabot alerts for `CVE-2026-53550` / `GHSA-h67p-54hq-rp68`:

- `https://github.com/groq/groq-typescript/security/dependabot/34`
- `https://github.com/groq/groq-typescript/security/dependabot/35`

That advisory is patched at `4.2.0` / `3.15.0`. Additionally, a newer merge-key quadratic-CPU issue, `CVE-2026-59869` / `GHSA-52cp-r559-cp3m` (not yet published in GitHub's advisory DB, surfaced by Codex review), affects `>=4.0.0 <4.3.0` and `>=3.0.0 <3.15.0`, so the `4.x` entry is pinned to `4.3.0` to cover both. `3.15.0` already covers both on the `3.x` line.

Both entries are transitive development dependencies in `yarn.lock`. The `4.x` entry is reachable through ESLint config loading in the CI lint path, and the `3.x` entry is reachable through Jest/Istanbul development tooling. The published SDK runtime has no direct `js-yaml` import and no runtime dependencies.

## Impact

- User-facing SDK runtime: no expected impact.
- CI/dev tooling: ESLint and Jest/Istanbul dependency resolution now uses the patched `js-yaml` versions.
- Regression watchpoints: YAML configs with pathological merge keys, aliases, numeric scalar edge cases, or malformed block/flow scalars may fail earlier under the patched parser behavior.

## Validation

- `npx --yes yarn@1.22.22 install --frozen-lockfile --ignore-scripts --non-interactive`
- `npx --yes yarn@1.22.22 lint`
- Targeted Node resolution checks:
  - `@eslint/eslintrc -> js-yaml@4.2.0` (now `4.3.0`)
  - `@istanbuljs/load-nyc-config -> js-yaml@3.15.0`
  - `require('@istanbuljs/load-nyc-config')` succeeds