### PR TITLE
chore: update CODEOWNERS (add @pmichalina-groq, remove @gradenr)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @gradenr @andrewtlw @cwilmott-groq
+* @gradenr @andrewtlw @cwilmott-groq @pmichalina-groq

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @gradenr @andrewtlw @cwilmott-groq @pmichalina-groq
+* @andrewtlw @cwilmott-groq @pmichalina-groq


### PR DESCRIPTION
Adds @pmichalina-groq as a code owner and removes @gradenr. The `main` ruleset requires a code-owner review, so today I can't approve/merge routine PRs here (e.g. dependency bumps like #264). This lets me help keep those moving.